### PR TITLE
Add `--save-location` CLI flag to miner and validator

### DIFF
--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -110,6 +110,12 @@ class Miner(BaseNode):
             action="store_true",
             help="Local run - use toy model, small enough for a laptop.",
         )
+        parser.add_argument(
+            "--save-location",
+            type=str,
+            default="/tmp",
+            help="Directory to save temporary files, gradients, checkpoints, and debug data.",
+        )
         bt.subtensor.add_args(parser)
         bt.logging.add_args(parser)
         bt.wallet.add_args(parser)
@@ -318,7 +324,7 @@ class Miner(BaseNode):
         # Init comms
         self.comms = tplr.comms.Comms(
             wallet=self.wallet,
-            save_location="/tmp",
+            save_location=self.config.save_location,
             key_prefix="model",
             config=self.config,
             netuid=self.config.netuid,

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -109,6 +109,12 @@ class Validator(BaseNode):
             action="store_true",
             help="Local run - use toy model, small enough for a laptop.",
         )
+        parser.add_argument(
+            "--save-location",
+            type=str,
+            default="/tmp",
+            help="Directory to save temporary files, gradients, checkpoints, and debug data.",
+        )
         bt.subtensor.add_args(parser)
         bt.logging.add_args(parser)
         bt.wallet.add_args(parser)
@@ -198,7 +204,7 @@ class Validator(BaseNode):
         # Init comms
         self.comms = tplr.comms.Comms(
             wallet=self.wallet,
-            save_location="/tmp",
+            save_location=self.config.save_location,
             key_prefix="model",
             config=self.config,
             netuid=self.config.netuid,

--- a/src/tplr/comms.py
+++ b/src/tplr/comms.py
@@ -48,7 +48,6 @@ from .schemas import Bucket
 
 # Constants
 CF_REGION_NAME: str = "enam"
-LOCAL_TMP_DIR = "/tmp/local_store"
 PEERS_FILE_PREFIX = "peers_"
 CPU_COUNT = os.cpu_count() or 4
 CPU_MAX_CONNECTIONS = min(100, max(30, CPU_COUNT * 4))
@@ -71,8 +70,11 @@ class Comms(ChainManager):
         self.wallet = wallet
 
         # Create temp directory for this instance
-        self.temp_dir = os.path.join("/tmp", f"templar_{self.uid}")
+        self.save_location = save_location
+        self.temp_dir = os.path.join(save_location, f"templar_{self.uid}")
         os.makedirs(self.temp_dir, exist_ok=True)
+        self.local_tmp_dir = os.path.join(save_location, f"local_store")
+        os.makedirs(self.local_tmp_dir, exist_ok=True)
         # Get the bucket directly
         self.bucket = self.get_own_bucket("gradients", "write")
         # Now initialize ChainManager with the bucket
@@ -88,7 +90,7 @@ class Comms(ChainManager):
         # Use the hotkey directly in the save_location
         if self.wallet is not None:
             hotkey = self.wallet.hotkey.ss58_address
-            self.save_location = os.path.join("/tmp", f"hotkey_{hotkey}")
+            self.save_location = os.path.join(save_location, f"hotkey_{hotkey}")
             os.makedirs(self.save_location, exist_ok=True)
         self.key_prefix = key_prefix
 
@@ -230,7 +232,7 @@ class Comms(ChainManager):
         self, uid: str, current_window: int, stale_retention: int
     ):
         """Clean up stale local data for a given uid."""
-        user_dir = os.path.join(LOCAL_TMP_DIR, str(uid))
+        user_dir = os.path.join(self.local_tmp_dir, str(uid))
         if not os.path.exists(user_dir):
             return
 
@@ -738,7 +740,7 @@ class Comms(ChainManager):
         put_start = tplr.T()
 
         # Create per-uid temp directory
-        temp_dir = os.path.join("/tmp", str(self.uid))
+        temp_dir = os.path.join(self.save_location, str(self.uid))
         os.makedirs(temp_dir, exist_ok=True)
         temp_file_path = os.path.join(temp_dir, f"temp_{filename}")
 
@@ -760,7 +762,7 @@ class Comms(ChainManager):
                 await self.cleanup_local_data(
                     uid=uid, current_window=window, stale_retention=stale_retention
                 )
-                local_dir = os.path.join(LOCAL_TMP_DIR, str(uid), str(window))
+                local_dir = os.path.join(self.local_tmp_dir, str(uid), str(window))
                 os.makedirs(local_dir, exist_ok=True)
                 final_path = os.path.join(local_dir, filename)
                 os.replace(temp_file_path, final_path)
@@ -825,7 +827,7 @@ class Comms(ChainManager):
                     uid=uid, current_window=window, stale_retention=stale_retention
                 )
                 local_path = os.path.join(
-                    LOCAL_TMP_DIR, str(uid), str(window), filename
+                    self.local_tmp_dir, str(uid), str(window), filename
                 )
                 if not os.path.exists(local_path):
                     tplr.logger.debug(f"Local file not found: {local_path}")
@@ -1414,7 +1416,7 @@ class Comms(ChainManager):
 
     def _load_latest_local_checkpoint(self, version: str):
         try:
-            local_dir = os.path.join(LOCAL_TMP_DIR, str(self.uid))
+            local_dir = os.path.join(self.local_tmp_dir, str(self.uid))
             pattern = rf"checkpoint-(\d+)-{self.uid}-v{re.escape(version)}\.pt$"
 
             if not os.path.exists(local_dir):


### PR DESCRIPTION
## Summary
This PR adds a configurable `--save-location` CLI flag to both the miner and validator scripts, allowing users to specify custom directories for temporary files, gradients, checkpoints, and debug data storage.

## Changes

### CLI Interface
- **Miner**: Added `--save-location` argument with default `/tmp`
- **Validator**: Added identical `--save-location` argument with same default
- Both maintain backward compatibility with existing scripts

### Comms Module Integration
- Updated comms initialization in both miner and validator to use `self.config.save_location` instead of hardcoded `/tmp`
- The comms module creates the following directory structure under the specified location:
  - `{save_location}/templar_{uid}/` - temporary processing files. Originally hardcoded to `/tmp/templar_{uid}`
  - `{save_location}/local_store/{uid}/{window}/` - local caching (gradients, checkpoints, debug data). Originally hardcoded to `/tmp/local_store/{uid}` via `LOCAL_TMP_DIR` constant 
  - `{save_location}/hotkey_{hotkey}/` - wallet-specific data. Originally hardcoded to `/tmp/hotkey_{hotkey}`

## Benefits
Users can now control where temporary and persistent data is stored. This includes storing all created files on a non-root disk.

## Backward Compatibility
✅ Fully backward compatible - existing scripts and configurations continue to work without modification since the default value remains `/tmp`.